### PR TITLE
[2/2] Retrospective lint fixes for Go sources

### DIFF
--- a/gpool.go
+++ b/gpool.go
@@ -34,7 +34,6 @@ type Pool struct {
 // NewPool returns a pool that uses semaphore implementation.
 // Returns ErrPoolInvalidSize if size is < 1.
 func NewPool(size int) *Pool {
-
 	if size < 0 {
 		panic(ErrPoolInvalidSize)
 	}
@@ -74,9 +73,10 @@ func (w *Pool) Start() {
 
 // Stop the Pool.
 //
-//		1- ALL Blocked/Waiting jobs will return immediately.
-// 		2- All Jobs Processing will finish successfully
-//		3- Stop() WILL Block until all running jobs i	s done.
+//	1- ALL Blocked/Waiting jobs will return immediately.
+//	2- All Jobs Processing will finish successfully
+//	3- Stop() WILL Block until all running jobs i	s done.
+//
 // Subsequent Calls to Stop() will have no effect unless start() is called.
 func (w *Pool) Stop() {
 	w.mu.Lock()
@@ -94,13 +94,11 @@ func (w *Pool) Stop() {
 
 	// Release the Semaphore so that subsequent enqueues will not block and return ErrPoolStopped.
 	w.semaphore.Release(int64(w.workerCount))
-
-	return
 }
 
 // Resize the pool size in concurrent-safe way.
 //
-//  `Resize` can enlarge the pool and any blocked enqueue will unblock after pool is resized, in case of shrinking the pool `resize` will not affect any already processing job.
+//	`Resize` can enlarge the pool and any blocked enqueue will unblock after pool is resized, in case of shrinking the pool `resize` will not affect any already processing job.
 func (w *Pool) Resize(newSize int) {
 	if newSize < 0 {
 		panic(ErrPoolInvalidSize)
@@ -127,16 +125,17 @@ func (w *Pool) Resize(newSize int) {
 // Enqueue Process job `func(){...}` and returns ONCE the func has started executing (not after it ends/return)
 //
 // If the pool is full `Enqueue()` will block until either:
-// 		1- A worker/slot in the pool is done and is ready to take the job.
-//		2- The Job context is canceled.
-//		3- The Pool is closed by `pool.Stop()`.
+//
+//	1- A worker/slot in the pool is done and is ready to take the job.
+//	2- The Job context is canceled.
+//	3- The Pool is closed by `pool.Stop()`.
+//
 // @Returns nil once the job has started executing.
 // @Returns ErrPoolStopped if the pool is not running.
 // @Returns ctx.Err() if the job Enqueued context was canceled before the job could be processed by the pool.
 func (w *Pool) Enqueue(ctx context.Context, job func()) error {
 	// Acquire 1 from semaphore ( aka Acquire one worker )
 	err := w.semaphore.Acquire(ctx, 1)
-
 	// The Job was canceled through job's context, no need to DO the work now.
 	if err != nil {
 		return err
@@ -162,17 +161,17 @@ func (w *Pool) Enqueue(ctx context.Context, job func()) error {
 // EnqueueAndWait Process job `func(){...}` and returns ONCE the func has returned.
 //
 // If the pool is full `Enqueue()` will block until either:
-// 		1- A worker/slot in the pool is done and is ready to take the job.
-//		2- The Job context is canceled.
-//		3- The Pool is closed by `pool.Stop()`.
+//
+//	1- A worker/slot in the pool is done and is ready to take the job.
+//	2- The Job context is canceled.
+//	3- The Pool is closed by `pool.Stop()`.
+//
 // @Returns nil once the job has executed and returned.
 // @Returns ErrPoolStopped if the pool is not running.
 // @Returns ctx.Err() if the job Enqueued context was canceled before the job could be processed by the pool.
 func (w *Pool) EnqueueAndWait(ctx context.Context, job func()) error {
-
 	// Acquire 1 from semaphore ( aka Acquire one worker )
 	err := w.semaphore.Acquire(ctx, 1)
-
 	// The Job was canceled through job's context, no need to DO the work now.
 	if err != nil {
 		return err

--- a/gpool_test.go
+++ b/gpool_test.go
@@ -18,7 +18,6 @@ func TestPool_Start(t *testing.T) {
 	// Test sizes for  < 0, 0 and > 0 size.
 	for size := -1; size <= 2; size++ {
 		t.Run(fmt.Sprintf("Size[%d]", size), func(t *testing.T) {
-
 			defer func() {
 				if r := recover(); r != nil {
 					if size >= 0 {
@@ -34,10 +33,10 @@ func TestPool_Start(t *testing.T) {
 			}
 
 			/// Send Work before Worker Start
-			Err := pool.Enqueue(context.TODO(), func() {})
+			_ = pool.Enqueue(context.TODO(), func() {})
 
 			/// Send Work before Worker Start with wait
-			Err = pool.EnqueueAndWait(context.TODO(), func() {})
+			_ = pool.EnqueueAndWait(context.TODO(), func() {})
 
 			/// Start Pool
 			pool.Start()
@@ -46,7 +45,7 @@ func TestPool_Start(t *testing.T) {
 			pool.Start()
 
 			// Enqueue a Job
-			Err = pool.Enqueue(context.TODO(), func() {})
+			Err := pool.Enqueue(context.TODO(), func() {})
 
 			if Err != nil {
 				t.Errorf("Pool Enqueued Errored after Start. Error: %s", Err.Error())
@@ -56,7 +55,6 @@ func TestPool_Start(t *testing.T) {
 }
 
 func TestPool_Stop(t *testing.T) {
-
 	pool := gpool.NewPool(10)
 
 	/// Start Worker
@@ -92,7 +90,6 @@ func TestPool_Stop(t *testing.T) {
 }
 
 func TestPool_Restart(t *testing.T) {
-
 	pool := gpool.NewPool(1)
 	/// Start Worker
 	pool.Start()
@@ -116,7 +113,6 @@ func TestPool_Restart(t *testing.T) {
 }
 
 func TestPool_Enqueue(t *testing.T) {
-
 	pool := gpool.NewPool(2)
 	// Start Worker
 	pool.Start()
@@ -139,7 +135,6 @@ func TestPool_Enqueue(t *testing.T) {
 }
 
 func TestPool_EnqueueAndWait(t *testing.T) {
-
 	pool := gpool.NewPool(2)
 	// Start Worker
 	pool.Start()
@@ -173,7 +168,6 @@ func TestPool_EnqueueAndWait(t *testing.T) {
 }
 
 func TestPool_EnqueueBlocking(t *testing.T) {
-
 	pool := gpool.NewPool(2)
 
 	// Create Context
@@ -239,7 +233,6 @@ func TestPool_EnqueueBlocking(t *testing.T) {
 }
 
 func TestPool_EnqueueAndWaitBlocking(t *testing.T) {
-
 	pool := gpool.NewPool(1)
 
 	// Create Context
@@ -262,11 +255,9 @@ func TestPool_EnqueueAndWaitBlocking(t *testing.T) {
 	if Err1 == nil {
 		t.Error("Didn't Return Error in a waiting & canceled job")
 	}
-
 }
 
 func TestPool_TryEnqueue(t *testing.T) {
-
 	pool := gpool.NewPool(2)
 	x := make(chan int, 1)
 
@@ -312,7 +303,6 @@ func TestPool_TryEnqueue(t *testing.T) {
 }
 
 func TestSemaphorePool_TryEnqueueAndWait(t *testing.T) {
-
 	pool := gpool.NewPool(2)
 	x := make(chan int, 1)
 
@@ -368,7 +358,6 @@ func TestSemaphorePool_TryEnqueueAndWait(t *testing.T) {
 }
 
 func TestPool_GetSize(t *testing.T) {
-
 	size := 10
 	pool := gpool.NewPool(size)
 	pool.Start()
@@ -462,7 +451,6 @@ func TestPool_PositiveResizeLive(t *testing.T) {
 }
 
 func TestPool_NegativeResizeLive(t *testing.T) {
-
 	size := 3
 	pool := gpool.NewPool(size)
 	pool.Start()
@@ -501,7 +489,6 @@ func TestPool_NegativeResizeLive(t *testing.T) {
 }
 
 func TestPool_Getters(t *testing.T) {
-
 	size := 2
 	pool := gpool.NewPool(size)
 	pool.Start()
@@ -553,7 +540,7 @@ func TestPool_Getters(t *testing.T) {
 // ------------ Benchmarking ------------
 
 func BenchmarkThroughput(b *testing.B) {
-	var workersCountValues = []int{runtime.GOMAXPROCS(0), 10, 100, 1000}
+	workersCountValues := []int{runtime.GOMAXPROCS(0), 10, 100, 1000}
 	for _, workercount := range workersCountValues {
 		b.Run(fmt.Sprintf("PoolSize[%d]", workercount), func(b *testing.B) {
 			pool := gpool.NewPool(workercount)
@@ -575,8 +562,8 @@ func BenchmarkThroughput(b *testing.B) {
 }
 
 func BenchmarkBulkJobs_UnderLimit(b *testing.B) {
-	var workersCountValues = []int{runtime.GOMAXPROCS(0), 10, 100, 1000, 10000}
-	var workAmountValues = []int{runtime.GOMAXPROCS(0), 100, 1000}
+	workersCountValues := []int{runtime.GOMAXPROCS(0), 10, 100, 1000, 10000}
+	workAmountValues := []int{runtime.GOMAXPROCS(0), 100, 1000}
 
 	for _, workercount := range workersCountValues {
 		for _, work := range workAmountValues {
@@ -692,7 +679,6 @@ func Example_three() {
 					time.Sleep(2000 * time.Millisecond)
 					x <- i
 				})
-
 				if err != nil {
 					log.Printf("Job [%v] was not enqueued. [%s]", i, err.Error())
 					return
@@ -700,14 +686,14 @@ func Example_three() {
 
 				log.Printf("Job [%v] Enqueue-ed ", i)
 
-				log.Printf("Job [%v] Receieved, Result: [%v]", i, <-x)
+				log.Printf("Job [%v] Received, Result: [%v]", i, <-x)
 			}(i)
 		}
 	}()
 
 	// Uncomment to demonstrate ctx cancel of jobs.
-	//time.Sleep(100 * time.Millisecond)
-	//cancel()
+	// time.Sleep(100 * time.Millisecond)
+	// cancel()
 
 	time.Sleep(5000 * time.Millisecond)
 

--- a/package.go
+++ b/package.go
@@ -1,12 +1,12 @@
 // Package gpool is used to easily manages a resizeable pool of context aware goroutines to bound concurrency, A Job is Enqueued to the pool and only N jobs can be processing concurrently.
 //
-//     A Job is simply a func(){} When you Enqueue(ctx, func(){}) a job the call will return ONCE the job has started processing. Otherwise if the pool is full it will block until:
-//     1. pool has room for the job.
-//     2. job's context is canceled.
-//     3. the pool is stopped.
-//     A Pool is either closed or started, the Pool will not accept any job unless pool.Start() is called.
-//     Stopping the Pool using pool.Stop() it will wait for all processing jobs to finish before returning, it will also unblock any blocked job enqueues (enqueues will return ErrPoolClosed).
-//     The Pool can be re-sized using Resize() that will resize the pool in a concurrent safe-way. Resize can enlarge the pool and any blocked enqueue will unblock after pool is resized, in case of shrinking the pool resize will not affect any already processing job.
-//     Enqueuing a Job will return error nil once a job starts, ErrPoolClosed if the pool is closed, or ctx.Err() if the job's context is canceled while blocking waiting for the pool.
-//     Start, Stop, and Resize(N) is all concurrent safe and can be called from multiple goroutines, subsequent calls of Start or Stop has no effect unless called interchangeably.
+//	A Job is simply a func(){} When you Enqueue(ctx, func(){}) a job the call will return ONCE the job has started processing. Otherwise if the pool is full it will block until:
+//	1. pool has room for the job.
+//	2. job's context is canceled.
+//	3. the pool is stopped.
+//	A Pool is either closed or started, the Pool will not accept any job unless pool.Start() is called.
+//	Stopping the Pool using pool.Stop() it will wait for all processing jobs to finish before returning, it will also unblock any blocked job enqueues (enqueues will return ErrPoolClosed).
+//	The Pool can be re-sized using Resize() that will resize the pool in a concurrent safe-way. Resize can enlarge the pool and any blocked enqueue will unblock after pool is resized, in case of shrinking the pool resize will not affect any already processing job.
+//	Enqueuing a Job will return error nil once a job starts, ErrPoolClosed if the pool is closed, or ctx.Err() if the job's context is canceled while blocking waiting for the pool.
+//	Start, Stop, and Resize(N) is all concurrent safe and can be called from multiple goroutines, subsequent calls of Start or Stop has no effect unless called interchangeably.
 package gpool


### PR DESCRIPTION
### Summary

<!-- pr:summary -->

Clear the existing-tree lint debt so `mise run check --all` (and the daily CI sweep) is green after the mise-fy rules land.

**Changes** <!-- pr:changes -->

- **Fixed**: gofumpt formatting on `gpool.go` / `gpool_test.go` / `package.go`
- **Fixed**: golangci `ineffassign` (discard unused pre-start enqueue results) + staticcheck redundant `return`
- **Fixed**: typos `Receieved` → `Received` in the example test

> [!NOTE]
> Stacked on [#1](https://github.com/sherifabdlnaby/gpool/pull/1). Merge [#1](https://github.com/sherifabdlnaby/gpool/pull/1) first; this PR retargets to `master` after.

<details><summary>Tests & Validation</summary>

- `mise run check --all` green (including go_fumpt check_diff)
- `mise run test` green

</details>

### Relevant Links

<!-- pr:links -->

- Previous: [#1](https://github.com/sherifabdlnaby/gpool/pull/1)

---

_<sub>🤖 Created with Cursor (Grok 4.5) on behalf of @sherifabdlnaby, fully autonomous, they have not reviewed this.</sub>_